### PR TITLE
replace async_setup_platforms with async_forward_entry_setups

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # TODO Optionally validate config entry options before setting up platform
 
     # Register platforms
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Register the options flow
     entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))


### PR DESCRIPTION
async_setup_platforms was removed in 2022.12 ([link](https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/))

Without this change, adding new devices using the integration results in error `AttributeError: 'ConfigEntries' object has no attribute 'async_setup_platforms'` and device fails to be created. 